### PR TITLE
Improve responsive image sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -19,6 +19,28 @@ img {
   height: auto;
   display: block;
 }
+/* Image helpers */
+.logo {
+  max-width: 150px;
+}
+.mission-title,
+.mission-text,
+.section-title,
+.quality-text,
+.contacts {
+  max-width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+.service-icon {
+  max-width: 80px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.service-heading {
+  max-width: 200px;
+  margin: 1rem auto;
+}
 header.navbar {
   display: flex;
   justify-content: space-between;
@@ -86,7 +108,7 @@ header.navbar a:hover {
 }
 .record-wrapper {
   position: relative;
-  width: 300px;
+  width: min(300px, 80vw);
   margin: 2rem auto;
 }
 .record-bg {
@@ -140,13 +162,27 @@ footer.footer {
   transform: translateY(0);
 }
 /* Responsive */
-@media (max-width: 768px) {
-  .service-list {
-    flex-direction: column;
-    align-items: center;
+  @media (max-width: 768px) {
+    .service-list {
+      flex-direction: column;
+      align-items: center;
+    }
+    header.navbar {
+      flex-direction: column;
+      gap: 1rem;
+    }
   }
-  header.navbar {
-    flex-direction: column;
-    gap: 1rem;
+  @media (max-width: 480px) {
+    .btn {
+      padding: 0.65rem 1.2rem;
+    }
+    .service {
+      max-width: 90%;
+    }
+    header.navbar {
+      padding: 1rem;
+    }
+    .logo {
+      max-width: 120px;
+    }
   }
-}


### PR DESCRIPTION
## Summary
- Add helper classes to control logo, icon, and text image sizes
- Make record illustration and buttons scale on small screens
- Introduce extra mobile breakpoint for tighter layout

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e2a387a5c832eb2c477bb0345e8e1