### PR TITLE
style: refine layout and card visuals

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@ img {
 .section-title,
 .quality-text,
 .contacts {
-  max-width: 90%;
+  width: min(90%, 600px);
   margin-left: auto;
   margin-right: auto;
 }
@@ -38,19 +38,20 @@ img {
   margin-right: auto;
 }
 .service-heading {
-  max-width: 200px;
+  width: min(80%, 200px);
   margin: 1rem auto;
 }
 header.navbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 2rem;
+  padding: 0.75rem 2rem;
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   background: var(--red);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   z-index: 1000;
 }
 header.navbar ul {
@@ -112,14 +113,15 @@ header.navbar a:hover {
   margin: 3rem 0;
 }
 .service {
-  background: #111;
+  background: transparent;
   padding: 1.5rem;
   border-radius: 8px;
   max-width: 320px;
+  border: 2px solid var(--red);
 }
 .service p {
   margin-top: 1rem;
-  color: var(--light);
+  color: var(--dark);
   font-size: 0.95rem;
 }
 .record-wrapper {


### PR DESCRIPTION
## Summary
- constrain heading image widths for better responsiveness
- lighten service cards and tweak their typography
- reduce header padding and add subtle shadow

## Testing
- `node --check script.js`
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_689e2f930358832eac748488d9df819a