### PR TITLE
feat: add responsive hero background videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,10 @@
   </header>
 
   <section class="hero">
-    <video class="hero-video desktop" autoplay muted loop playsinline>
+    <video class="hero-video desktop" autoplay muted loop playsinline preload="auto" aria-hidden="true">
       <source src="Video.mp4" type="video/mp4">
     </video>
-    <video class="hero-video mobile" autoplay muted loop playsinline>
+    <video class="hero-video mobile" autoplay muted loop playsinline preload="auto" aria-hidden="true">
       <source src="celular.mp4" type="video/mp4">
     </video>
     <div class="hero-content fade-in">

--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,7 @@ header.navbar a:hover {
   padding: 2rem;
   color: var(--light);
   position: relative;
+  overflow: hidden;
 }
 .hero-content {
   display: flex;
@@ -116,8 +117,9 @@ header.navbar a:hover {
   height: 100%;
   object-fit: cover;
   z-index: -1;
+  pointer-events: none;
+  display: none;
 }
-.hero-video.desktop { display: none; }
 .hero-record { display: none; }
 .section {
   padding: 6rem 2rem 2rem;
@@ -227,6 +229,9 @@ footer.footer {
       flex-direction: column;
       gap: 1rem;
     }
+    .hero-video.mobile {
+      display: block;
+    }
     .hero-record {
       display: block;
       margin-top: 1rem;
@@ -255,7 +260,6 @@ footer.footer {
       color: var(--dark);
     }
     .hero-video.desktop { display: block; }
-    .hero-video.mobile { display: none; }
     .service {
       border: none;
     }


### PR DESCRIPTION
## Summary
- play Video.mp4 as hero background on desktop and celular.mp4 on mobile
- ensure hero video covers section and ignores pointer events

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f98e8c8d0832ebd4d64d55a43227c