### PR TITLE
Ensure separate desktop and mobile background videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,9 @@
   </header>
 
   <section class="hero">
-    <video class="hero-video desktop" autoplay muted loop playsinline preload="auto" aria-hidden="true">
-      <source src="Video.mp4" type="video/mp4">
-    </video>
-    <video class="hero-video mobile" autoplay muted loop playsinline preload="auto" aria-hidden="true">
-      <source src="celular.mp4" type="video/mp4">
+    <video class="hero-video" autoplay muted loop playsinline preload="auto" aria-hidden="true">
+      <source src="video.mp4" type="video/mp4" media="(min-width: 769px)">
+      <source src="celular.mp4" type="video/mp4" media="(max-width: 768px)">
     </video>
     <div class="hero-content fade-in">
       <img src="mesmasecao1%20-%20Cor_fff2e2.png" alt="Nossa Missão" class="mission-title">

--- a/styles.css
+++ b/styles.css
@@ -120,7 +120,6 @@ header.navbar a:hover {
   object-fit: cover;
   z-index: -1;
   pointer-events: none;
-  display: none;
 }
 .hero-record { display: none; }
 .section {
@@ -231,9 +230,6 @@ footer.footer {
       flex-direction: column;
       gap: 1rem;
     }
-    .hero-video.mobile {
-      display: block;
-    }
     .hero-record {
       display: block;
       margin-top: 1rem;
@@ -261,7 +257,6 @@ footer.footer {
       background-image: none;
       color: var(--dark);
     }
-    .hero-video.desktop { display: block; }
     .service {
       border: none;
     }


### PR DESCRIPTION
## Summary
- Load `video.mp4` only on desktop and `celular.mp4` only on mobile
- Simplify hero video markup and styling for responsive backgrounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dcaf1bec832e8a1b7f5ed30cfdff