### PR TITLE
Enable responsive hero background video autoplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,7 @@
   </header>
 
   <section class="hero">
-    <video class="hero-video" autoplay muted loop playsinline preload="auto" aria-hidden="true">
-      <source src="video.mp4" type="video/mp4" media="(min-width: 769px)">
-      <source src="celular.mp4" type="video/mp4" media="(max-width: 768px)">
-    </video>
+    <video class="hero-video" autoplay muted loop playsinline preload="auto" aria-hidden="true"></video>
     <div class="hero-content fade-in">
       <img src="mesmasecao1%20-%20Cor_fff2e2.png" alt="Nossa Missão" class="mission-title">
       <img src="Cor_fff2e2.png" alt="Transformar inspirações em músicas que tocam o coração de Deus" class="mission-text">

--- a/script.js
+++ b/script.js
@@ -12,6 +12,13 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
 
   document.querySelectorAll('.hero-video').forEach(video => {
+    const isMobile = window.matchMedia('(max-width: 768px)').matches;
+    const source = document.createElement('source');
+    source.src = isMobile ? 'celular.mp4' : 'video.mp4';
+    source.type = 'video/mp4';
+    video.appendChild(source);
+    video.load();
+
     const playPromise = video.play();
     if (playPromise !== undefined) {
       playPromise.catch(() => {

--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,8 @@ header.navbar a:hover {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  position: relative;
+  z-index: 1;
 }
 .hero-content img {
   margin: 0.5rem 0;
@@ -118,7 +120,7 @@ header.navbar a:hover {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  z-index: -1;
+  z-index: 0;
   pointer-events: none;
 }
 .hero-record { display: none; }


### PR DESCRIPTION
## Summary
- Load hero background video dynamically for desktop and mobile
- Ensure hero content overlays an autoplaying video

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f7b73308832e92670855cd903784