### PR TITLE
Improve hero mobile layout and mission image sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -44,7 +44,7 @@ img {
   margin-left: auto;
   margin-right: auto;
   width: auto;
-  max-width: none;
+  max-width: 250px;
 }
 .service-image {
   width: 200px;
@@ -224,6 +224,16 @@ footer.footer {
 }
 /* Responsive */
   @media (max-width: 768px) {
+    .hero {
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      background-size: cover;
+      background-position: center;
+    }
+    .hero-content {
+      align-items: center;
+    }
     .service-list {
       flex-direction: column;
       align-items: center;


### PR DESCRIPTION
## Summary
- Limit mission title image to natural 250px width
- Center hero content and adjust background for mobile screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f9f1ffa4832ea2640716a18b6233